### PR TITLE
Update  docs to use `fisher install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@
 
 ## Installation
 
-1. Run `fisher add silver-prompt/fish` in `fish`
+1. Run `fisher install silver-prompt/fish` in `fish`


### PR DESCRIPTION
`fisher add` is no longer valid since [Fisher 4.0](https://github.com/jorgebucaran/fisher/pull/596/files)